### PR TITLE
Add support for Kerberos authentication and LDAPS

### DIFF
--- a/pygpoabuse.py
+++ b/pygpoabuse.py
@@ -13,6 +13,7 @@ import re
 import sys
 
 from impacket.smbconnection import SMBConnection
+from impacket.examples.utils import parse_credentials
 
 from pygpoabuse import logger
 from pygpoabuse.gpo import GPO
@@ -29,6 +30,14 @@ parser.add_argument('-description', action='store', help='Task description (Defa
 parser.add_argument('-powershell', action='store_true', help='Use Powershell for command execution')
 parser.add_argument('-command', action='store',
                     help='Command to execute (Default: Add john:H4x00r123.. as local Administrator)')
+parser.add_argument('-k', action='store_true', help='Use Kerberos authentication. Grabs credentials from ccache file '
+                                        '(KRB5CCNAME) based on target parameters. If valid credentials '
+                                        'cannot be found, it will use the ones specified in the command '
+                                        'line')
+parser.add_argument('-no-pass', action='store_true', help='Don\'t ask for password (useful for -k)'),
+parser.add_argument('-dc-ip', action='store', help='Domain controller IP or hostname to query')
+parser.add_argument('-ldaps', action='store_true', help='Use LDAPS for authentication')
+parser.add_argument('-ccache', action='store', help='ccache file name (must be in local directory)')
 parser.add_argument('-f', action='store_true', help='Force add ScheduleTask')
 parser.add_argument('-v', action='count', default=0, help='Verbosity level (-v or -vv)')
 
@@ -52,20 +61,18 @@ elif options.v >= 2:
 else:
     logging.getLogger().setLevel(logging.ERROR)
 
-targetParam = options.target 
-domain, username, password, address = re.compile('(?:(?:([^/@:]*)/)?([^@:]*)(?::([^@]*))?@)?(.*)').match(
-    targetParam).groups('')
+domain, username, password = parse_credentials(options.target)
 
-# In case the password contains '@'
-if '@' in address:
-    password = password + '@' + address.rpartition('@')[0]
-    address = address.rpartition('@')[2]
+if options.dc_ip:
+    address = options.dc_ip
+else:
+    address = domain
 
 if domain == '':
     logging.critical('Domain should be specified!')
     sys.exit(1)
 
-if password == '' and username != '' and options.hashes is None:
+if password == '' and username != '' and options.hashes is None and options.no_pass is False:
     from getpass import getpass
     password = getpass("Password:")
 elif options.hashes is not None:
@@ -73,12 +80,23 @@ elif options.hashes is not None:
         logging.error("Wrong hash format. Expecting lm:nt")
         sys.exit(1)
 
-dc_ip = domain
-if password != '':
-    url = 'ldap+ntlm-password://{}\\{}:{}@{}'.format(domain, username, password, address)
+dc_ip = address
+
+if options.ldaps:
+    protocol = 'ldaps'
+else:
+    protocol = 'ldap'
+
+if options.k:
+    if not options.ccache:
+        logging.error('Name of ccache file in local directory required')
+        sys.exit(1)
+    url = '{}+kerberos-ccache://{}\\{}:{}@{}/?dc={}'.format(protocol, domain, username, options.ccache, address, address)
+elif password != '':
+    url = '{}+ntlm-password://{}\\{}:{}@{}'.format(protocol, domain, username, password, address)
     lmhash, nthash = "",""
 else:
-    url = 'ldap+ntlm-nt://{}\\{}:{}@{}'.format(domain, username, options.hashes.split(":")[1], address)
+    url = '{}+ntlm-nt://{}\\{}:{}@{}'.format(protocol, domain, username, options.hashes.split(":")[1], address)
     lmhash, nthash = options.hashes.split(":")
 
 
@@ -93,7 +111,10 @@ def get_session(address, target_ip="", username="", password="", lmhash="", ntha
 
 try:
     smb_session = SMBConnection(dc_ip, dc_ip)
-    smb_session.login(username, password, domain, lmhash, nthash)
+    if options.k:
+        smb_session.kerberosLogin(user=username, password='', domain=domain, kdcHost=dc_ip)
+    else:
+        smb_session.login(username, password, domain, lmhash, nthash)
 except Exception as e:
     logging.error("SMB connection error", exc_info=True)
     sys.exit(1)


### PR DESCRIPTION
This adds CLI flags to support Kerberos authentication (only ccache method) for the SMB and LDAP connections made. 

## Notes
- Setting the `KRB5CCNAME` environment variable works for the SMB conn via Impacket, but doesn't appear to be compatible with msldap. Workaround is to provide the path to the ccache file with the `-ccache` flag, which msldap seems to require in the local directory
- Switched credential parsing to use Impacket's `parse_credentials()` func