### PR TITLE
Fixed bug in update_extensionNames which would break existing GPOs

### DIFF
--- a/pygpoabuse/gpo.py
+++ b/pygpoabuse/gpo.py
@@ -20,7 +20,7 @@ class GPO:
         try:
             if not val2 in extensionName:
                 new_values = []
-                toUpdate = extensionName
+                toUpdate = ''.join(extensionName)
                 test = toUpdate.split("[")
                 for i in test:
                     new_values.append(i.replace("{", "").replace("}", " ").replace("]", ""))


### PR DESCRIPTION
Fixed bug where update_extensionNames would always fail over to just writing the new values instead of maintaining the existing values due to attempting to perform .split() on a list.