### PR TITLE
Pass GPO type to ScheduledTask creation

### DIFF
--- a/pygpoabuse/gpo.py
+++ b/pygpoabuse/gpo.py
@@ -202,7 +202,7 @@ class GPO:
             except:
                 logging.error("This user doesn't seem to have the necessary rights", exc_info=True)
                 return False
-            st = ScheduledTask(name=name, mod_date=mod_date, description=description, powershell=powershell, command=command)
+            st = ScheduledTask(gpo_type=gpo_type, name=name, mod_date=mod_date, description=description, powershell=powershell, command=command)
             new_content = st.generate_scheduled_task_xml()
 
         try:


### PR DESCRIPTION
Currently, user GPOs are executed with NT AUTHORITY\SYSTEM permissions instead of the intended behavior of the currently logged in user. This is because the supplied gpo_type is never passed to the ScheduledTask constructor, which defaults to creating computer GPOs with the NT AUTHORITY\SYSTEM user.

This PR passes the gpo_type field to the constructor so that ScheduledTasks are created with the intended behavior.